### PR TITLE
Make extension run with TYPO3 v12

### DIFF
--- a/Classes/Backend/Form/Element/CheckboxToggleWithTypoScriptPlaceholderElement.php
+++ b/Classes/Backend/Form/Element/CheckboxToggleWithTypoScriptPlaceholderElement.php
@@ -29,6 +29,7 @@ use WapplerSystems\WsSlider\Service\TypoScriptService;
  */
 class CheckboxToggleWithTypoScriptPlaceholderElement extends AbstractFormElement
 {
+    private IconRegistry $iconRegistry;
 
     /**
      * Default field information enabled for this element.

--- a/Classes/Backend/Form/Element/SelectSingleWithTypoScriptPlaceholderElement.php
+++ b/Classes/Backend/Form/Element/SelectSingleWithTypoScriptPlaceholderElement.php
@@ -22,6 +22,8 @@ use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
 use TYPO3\CMS\Core\Utility\DebugUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\StringUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use WapplerSystems\WsSlider\Configuration\ConfigurationManager;
 use WapplerSystems\WsSlider\Service\TypoScriptService;
 
 /**
@@ -323,6 +325,29 @@ class SelectSingleWithTypoScriptPlaceholderElement extends AbstractFormElement
 
         $resultArray['html'] = '<div class="formengine-field-item t3js-formengine-field-item">' . $fieldInformationHtml . $fullElement . '</div>';
         return $resultArray;
+    }
+
+
+    private function getTypoScriptValue($path)
+    {
+
+        $tsArray = GeneralUtility::makeInstance(ConfigurationManager::class)
+            ->getConfiguration(
+                ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
+            );
+        $segments = GeneralUtility::trimExplode('.', $path);
+
+        $lastSegment = array_pop($segments);
+        foreach ($segments as $segment) {
+            if (isset($tsArray[$segment . '.'])) {
+                $tsArray = $tsArray[$segment . '.'];
+            } else {
+                return null;
+            }
+        }
+        if (isset($tsArray[$lastSegment])) return $tsArray[$lastSegment];
+
+        return null;
     }
 
 }

--- a/Classes/Backend/Form/FormDataProvider/TcaSelectItemsEnhancer.php
+++ b/Classes/Backend/Form/FormDataProvider/TcaSelectItemsEnhancer.php
@@ -7,7 +7,6 @@ namespace WapplerSystems\WsSlider\Backend\Form\FormDataProvider;
 use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class TcaSelectItemsEnhancer implements FormDataProviderInterface
 {
@@ -38,8 +37,7 @@ class TcaSelectItemsEnhancer implements FormDataProviderInterface
 
     private function getTypoScriptSettings()
     {
-        return GeneralUtility::makeInstance(ObjectManager::class)
-                ->get(ConfigurationManagerInterface::class)
+        return GeneralUtility::makeInstance(ConfigurationManagerInterface::class)
                 ->getConfiguration(
                     ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
                 )['plugin.']['tx_gomapsext.']['settings.'] ?? [];

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -7,6 +7,8 @@ use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WapplerSystems\WsSlider\Service\TypoScriptService;
+use TYPO3\CMS\Core\Utility\StringUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use WapplerSystems\WsSlider\Utility\TemplateLayout;
 
 /**
@@ -142,6 +144,30 @@ class ItemsProcFunc
 
         $row = BackendUtilityCore::getRecord('tt_content', abs($pid), 'uid,pid');
         return $row['pid'];
+    }
+
+
+    private function getTypoScriptValue($path)
+    {
+
+        $tsArray = GeneralUtility::makeInstance(ConfigurationManagerInterface::class)
+            ->getConfiguration(
+                ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
+            );
+
+        $segments = GeneralUtility::trimExplode('.', $path);
+
+        $lastSegment = array_pop($segments);
+        foreach ($segments as $segment) {
+            if (isset($tsArray[$segment . '.'])) {
+                $tsArray = $tsArray[$segment . '.'];
+            } else {
+                return null;
+            }
+        }
+        if (isset($tsArray[$lastSegment])) return $tsArray[$lastSegment];
+
+        return null;
     }
 
 

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -2,6 +2,8 @@
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
+defined('TYPO3') || die();
+
 
 ExtensionManagementUtility::addStaticFile('ws_slider', 'Configuration/TypoScript',
     'WS Slider General Settings');

--- a/Configuration/TCA/tx_wsslider_domain_model_item.php
+++ b/Configuration/TCA/tx_wsslider_domain_model_item.php
@@ -1,6 +1,9 @@
 <?php
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Resource\File;
+if (!defined('TYPO3')) {
+    die ('Access denied.');
+}
 
 return [
     'ctrl' => [
@@ -27,8 +30,6 @@ return [
         'security' => [
             'ignorePageTypeRestriction' => true,
         ]
-    ],
-    'interface' => [
     ],
     'types' => [
         '1' => [
@@ -265,4 +266,3 @@ return [
         ],
     ],
 ];
-

--- a/Configuration/TCA/tx_wsslider_domain_model_item.php
+++ b/Configuration/TCA/tx_wsslider_domain_model_item.php
@@ -191,23 +191,14 @@ return [
                             'width' => 90
                         ]
                     ],
-                    'foreign_match_fields' => [
-                        'fieldname' => 'foreground_media',
-                        'tablenames' => 'tx_wsslider_domain_model_item',
-                        'table_local' => 'sys_file',
-                    ],
                     'overrideChildTca' => [
                         'types' => [
                             File::FILETYPE_IMAGE => [
                                 'showitem' => '
                                     --palette--;;imageoverlayPalette,
                                     --palette--;;filePalette'
-                            ], '0' => [
-                                'showitem' => '
-                                --palette--;LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:sys_file_reference.imageoverlayPalette,
-                                --palette--;;imageoverlayPalette,
-                                --palette--;;filePalette'
-                            ], File::FILETYPE_IMAGE => [
+                            ],
+                            '0' => [
                                 'showitem' => '
                                 --palette--;LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:sys_file_reference.imageoverlayPalette,
                                 --palette--;;imageoverlayPalette,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,6 +7,9 @@ use WapplerSystems\WsSlider\Backend\Form\Element\SelectSingleWithTypoScriptPlace
 use WapplerSystems\WsSlider\Backend\Form\Element\InputTextWithTypoScriptPlaceholderElement;
 use WapplerSystems\WsSlider\Updates\WsFlexsliderMigration;
 
+if (!defined('TYPO3_MODE')) {
+    die ('Access denied.');
+}
 call_user_func(
     function ($extKey) {
 
@@ -17,12 +20,16 @@ call_user_func(
             ExtensionManagementUtility::addPageTSConfig('@import "EXT:my_sitepackage/Configuration/page.tsconfig"');
         }
 
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1586633307] = [
+
+        ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:ws_slider/Configuration/TsConfig/Page/General.tsconfig">');
+
+
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1_586_633_307] = [
             'nodeName' => 'selectSingleWithTypoScriptPlaceholder',
             'priority' => '70',
             'class' => SelectSingleWithTypoScriptPlaceholderElement::class,
         ];
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1586633308] = [
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1_586_633_308] = [
             'nodeName' => 'inputWithTypoScriptPlaceholder',
             'priority' => '70',
             'class' => InputTextWithTypoScriptPlaceholderElement::class,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,11 +13,23 @@ if (!defined('TYPO3_MODE')) {
 call_user_func(
     function ($extKey) {
 
-        $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
-        // Only include page.tsconfig if TYPO3 version is below 12 so that it is not imported twice.
-        // TODO: Drop this when dropping TYPO3 v11 support
-        if ($versionInformation->getMajorVersion() < 12) {
-            ExtensionManagementUtility::addPageTSConfig('@import "EXT:my_sitepackage/Configuration/page.tsconfig"');
+
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FlexFormTools::class]['flexParsing'][FlexFormEnhancerHook::class] = FlexFormEnhancerHook::class;
+
+
+        if (TYPO3_MODE === 'BE') {
+            $icons = [
+                'content-wsslider' => 'content-wsslider.svg',
+                'ext-wsslider-image' => 'image.svg'
+            ];
+            $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
+            foreach ($icons as $identifier => $path) {
+                $iconRegistry->registerIcon(
+                    $identifier,
+                    SvgIconProvider::class,
+                    ['source' => 'EXT:' . $extKey . '/Resources/Public/Icons/' . $path]
+                );
+            }
         }
 
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,33 +7,20 @@ use WapplerSystems\WsSlider\Backend\Form\Element\SelectSingleWithTypoScriptPlace
 use WapplerSystems\WsSlider\Backend\Form\Element\InputTextWithTypoScriptPlaceholderElement;
 use WapplerSystems\WsSlider\Updates\WsFlexsliderMigration;
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die ('Access denied.');
 }
 call_user_func(
     function ($extKey) {
 
-
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FlexFormTools::class]['flexParsing'][FlexFormEnhancerHook::class] = FlexFormEnhancerHook::class;
-
-
-        if (TYPO3_MODE === 'BE') {
-            $icons = [
-                'content-wsslider' => 'content-wsslider.svg',
-                'ext-wsslider-image' => 'image.svg'
-            ];
-            $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
-            foreach ($icons as $identifier => $path) {
-                $iconRegistry->registerIcon(
-                    $identifier,
-                    SvgIconProvider::class,
-                    ['source' => 'EXT:' . $extKey . '/Resources/Public/Icons/' . $path]
-                );
-            }
+        $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
+        // Only include page.tsconfig if TYPO3 version is below 12 so that it is not imported twice.
+        // TODO: Drop this when dropping TYPO3 v11 support
+        if ($versionInformation->getMajorVersion() < 12) {
+            ExtensionManagementUtility::addPageTSConfig('@import "EXT:my_sitepackage/Configuration/page.tsconfig"');
         }
 
-
-        ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:ws_slider/Configuration/TsConfig/Page/General.tsconfig">');
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FlexFormTools::class]['flexParsing'][FlexFormEnhancerHook::class] = FlexFormEnhancerHook::class;
 
 
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1_586_633_307] = [

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,7 +1,8 @@
 <?php
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-
-
+if (!defined('TYPO3')) {
+    die ('Access denied.');
+}
 
 call_user_func(
     function ($extKey) {


### PR DESCRIPTION
The following changes make the extension run with TYPO3 v12.4

I tested the results only with what I need (Flexslider) so some adjustments might be needed for the other Libaries.

Please do not squash but keep individual commits.